### PR TITLE
Added example sentences to German phrasal verbs

### DIFF
--- a/src/containers/data/phrasalVerbsGe.ts
+++ b/src/containers/data/phrasalVerbsGe.ts
@@ -4,667 +4,778 @@ export default {
       pVerb: "abhängen",
       prae: "von",
       kasus: "D",
-      translationGe: "to depend on (sth.)"
+      translationGe: "to depend on (sth.)",
+      exampleSentence: "Ob wir fahren, hängt vom Wetter ab."
     },
     {
       pVerb: "achten",
       prae: "auf",
       kasus: "A",
-      translationGe: "to mind (sth.)"
+      translationGe: "to mind (sth.)",
+      exampleSentence: "Bitte achte auf den neuen Mantel."
     },
     {
       pVerb: "anfangen",
       prae: "mit",
       kasus: "D",
-      translationGe: "to start with (sth.)"
+      translationGe: "to start with (sth.)",
+      exampleSentence: "Ich fange mit der Übung an."
     },
     {
       pVerb: "ankommen",
       prae: "auf",
       kasus: "A",
-      translationGe: "to depend on (sth.)"
+      translationGe: "to depend on (sth.)",
+      exampleSentence: "Es kommt auf den richtigen Preis an."
     },
     {
       pVerb: "antworten",
       prae: "auf",
       kasus: "A",
-      translationGe: "to respond to (sth.)"
+      translationGe: "to respond to (sth.)",
+      exampleSentence: "Bitte antworten Sie heute auf den Brief."
     },
     {
       pVerb: "sich ärgern",
       prae: "über",
       kasus: "A",
-      translationGe: "to get angry about (sth.)"
+      translationGe: "to get angry about (sth.)",
+      exampleSentence: "Wir ärgern uns über den Regen."
     },
     {
       pVerb: "aufhören",
       prae: "mit",
       kasus: "D",
-      translationGe: "to stop with (sth.)"
+      translationGe: "to stop with (sth.)",
+      exampleSentence: "Er hört um 17.00 Uhr mit der Arbeit auf."
     },
     {
       pVerb: "aufpassen",
       prae: "auf",
       kasus: "A",
-      translationGe: "to pay attention to (sth.)"
+      translationGe: "to pay attention to (sth.)",
+      exampleSentence: "Ein Babysitter passt auf kleine Kinder auf."
     },
     {
       pVerb: "sich aufregen",
       prae: "über",
       kasus: "A",
-      translationGe: "to get upset about (sth.)"
+      translationGe: "to get upset about (sth.)",
+      exampleSentence: "Deutsche regen sich über Unpünktlichkeit auf."
     },
     {
       pVerb: "ausgeben",
       prae: "für",
       kasus: "A",
-      translationGe: "to pay for (sth.)"
+      translationGe: "to pay for (sth.)",
+      exampleSentence: "Frauen geben viel Geld für Schuhe aus."
     },
     {
       pVerb: "sich bedanken",
       prae: "bei",
       kasus: "D",
-      translationGe: "to thank (so.)"
+      translationGe: "to thank (so.)",
+      exampleSentence: "Ich bedanke mich herzlich bei dir."
     },
     {
       pVerb: "sich bedanken",
       prae: "für",
       kasus: "A",
-      translationGe: "to thank for (sth.)"
+      translationGe: "to thank for (sth.)",
+      exampleSentence: "Martin bedankt sich für das Geschenk."
     },
     {
       pVerb: "beginnen",
       prae: "mit",
       kasus: "D",
-      translationGe: "to start with (sth.)"
+      translationGe: "to start with (sth.)",
+      exampleSentence: "Wir beginnen pünktlich mit dem Deutschkurs."
     },
     {
       pVerb: "sich bemühen",
       prae: "um",
       kasus: "A",
-      translationGe: "to go after (sth.)"
+      translationGe: "to go after (sth.)",
+      exampleSentence: "Karla bemüht sich um eine Arbeit."
     },
     {
       pVerb: "berichten",
       prae: "über",
       kasus: "A",
-      translationGe: "to report on (sth.)"
+      translationGe: "to report on (sth.)",
+      exampleSentence: "Der Reporter berichtet über die Wahlen."
     },
     {
       pVerb: "sich beschäftigen",
       prae: "mit",
       kasus: "D",
-      translationGe: "to occupy oneself with (sth.)"
+      translationGe: "to occupy oneself with (sth.)",
+      exampleSentence: "Ich beschäftige mich gern mit Pflanzen."
     },
     {
       pVerb: "sich beschweren",
       prae: "bei",
       kasus: "D",
-      translationGe: "to complain to (sb.)"
+      translationGe: "to complain to (sb.)",
+      exampleSentence: "Der Gast beschwert sich beim Kellner."
     },
     {
       pVerb: "bestehen",
       prae: "aus",
       kasus: "D",
-      translationGe: "to consist of (sth.)"
+      translationGe: "to consist of (sth.)",
+      exampleSentence: "Eheringe bestehen aus Gold."
     },
     {
       pVerb: "bestehen",
       prae: "auf",
       kasus: "A",
-      translationGe: "to insist on (sth.)"
+      translationGe: "to insist on (sth.)",
+      exampleSentence: "Ich bestehe auf sofortige Bezahlung des Autos."
     },
     {
       pVerb: "sich beteiligen",
       prae: "an",
       kasus: "D",
-      translationGe: "to take part in (sth.)"
+      translationGe: "to take part in (sth.)",
+      exampleSentence: "Viele Studenten beteiligen sich an den Streiks."
     },
     {
       pVerb: "sich bewerben",
       prae: "bei",
       kasus: "D",
-      translationGe: "to apply to (so.)"
+      translationGe: "to apply to (so.)",
+      exampleSentence: "Er bewirbt sich bei einer Bäckerei."
     },
     {
       pVerb: "sich bewerben",
       prae: "um",
       kasus: "A",
-      translationGe: "to apply for (sth.)"
+      translationGe: "to apply for (sth.)",
+      exampleSentence: "Sie bewirbt sich um eine Stelle als Sekretärin."
     },
     {
       pVerb: "sich beziehen",
       prae: "auf",
       kasus: "A",
-      translationGe: "to refer to (sth.)"
+      translationGe: "to refer to (sth.)",
+      exampleSentence: "Meine Frage bezieht sich auf Ihr Angebot."
     },
     {
       pVerb: "bitten",
       prae: "um",
       kasus: "A",
-      translationGe: "to ask for (sth.)"
+      translationGe: "to ask for (sth.)",
+      exampleSentence: "Der Redner bittet um Aufmerksamkeit."
     },
     {
       pVerb: "danken",
       prae: "für",
       kasus: "A",
-      translationGe: "to thank for (sth.)"
+      translationGe: "to thank for (sth.)",
+      exampleSentence: "Sam dankt für Ritas Hilfe."
     },
     {
       pVerb: "denken",
       prae: "an",
       kasus: "A",
-      translationGe: "to think of (sth.)"
+      translationGe: "to think of (sth.)",
+      exampleSentence: "Maria denkt oft an den Urlaub."
     },
     {
       pVerb: "diskutieren",
       prae: "über",
       kasus: "A",
-      translationGe: "to discuss (sth.)"
+      translationGe: "to discuss (sth.)",
+      exampleSentence: "Das Kabinett diskutiert über eine neue Steuer."
     },
     {
       pVerb: "einladen",
       prae: "zu",
       kasus: "D",
-      translationGe: "to invite (sb.) to (sth.)"
+      translationGe: "to invite (sb.) to (sth.)",
+      exampleSentence: "Ich lade dich zu meinem Geburtstag ein."
     },
     {
       pVerb: "sich entscheiden",
       prae: "für",
       kasus: "A",
-      translationGe: "to decide on (sth.)"
+      translationGe: "to decide on (sth.)",
+      exampleSentence: "Frauen entscheiden sich gern für Gold."
     },
     {
       pVerb: "sich entschließen",
       prae: "zu",
       kasus: "D",
-      translationGe: "to decide to (sth.)"
+      translationGe: "to decide to (sth.)",
+      exampleSentence: "Karl entschließt sich zu einem Studium."
     },
     {
       pVerb: "sich entschuldigen",
       prae: "bei",
       kasus: "D",
-      translationGe: "to apologize by (so.)"
+      translationGe: "to apologize by (so.)",
+      exampleSentence: "Mia entschuldigt sich bei ihrem Mann."
     },
     {
       pVerb: "sich entschuldigen",
       prae: "für",
       kasus: "A",
-      translationGe: "to apologize for (sth.)"
+      translationGe: "to apologize for (sth.)",
+      exampleSentence: "Ich entschuldige mich für das Verhalten meiner Tochter."
     },
     {
       pVerb: "erfahren",
       prae: "von",
       kasus: "D",
-      translationGe: "to find out about (sth.)"
+      translationGe: "to find out about (sth.)",
+      exampleSentence: "Heute haben wir von dem Bauprojekt erfahren."
     },
     {
       pVerb: "sich erholen",
       prae: "von",
       kasus: "D",
-      translationGe: "to recover from (sth.)"
+      translationGe: "to recover from (sth.)",
+      exampleSentence: "Von dem Schock muss ich mich erst erholen."
     },
     {
       pVerb: "sich erinnern",
       prae: "an",
       kasus: "A",
-      translationGe: "to remember (sth.)"
+      translationGe: "to remember (sth.)",
+      exampleSentence: "Wir erinnern uns gern an unser erstes Ehejahr."
     },
     {
       pVerb: "erkennen",
       prae: "an",
       kasus: "D",
-      translationGe: "to recognize from (sth.)"
+      translationGe: "to recognize from (sth.)",
+      exampleSentence: "Man erkennt Pinocchio an seiner langen Nase."
     },
     {
       pVerb: "sich erkundigen",
       prae: "nach",
       kasus: "D",
-      translationGe: "to inquire about (sth.)"
+      translationGe: "to inquire about (sth.)",
+      exampleSentence: "Oma erkundigt sich oft nach meinen Plänen."
     },
     {
       pVerb: "erschrecken",
       prae: "über",
       kasus: "A",
-      translationGe: "to get spooked by (sth.)"
+      translationGe: "to get spooked by (sth.)",
+      exampleSentence: "Die Frau erschrickt über eine Maus."
     },
     {
       pVerb: "erzählen",
       prae: "über",
       kasus: "A",
-      translationGe: "to tell (sth.)"
+      translationGe: "to tell (sth.)",
+      exampleSentence: "Ein Ostberliner erzählt über sein Leben in der ehemaligen DDR."
     },
     {
       pVerb: "erzählen",
       prae: "von",
       kasus: "D",
-      translationGe: "to tell of (sth.)"
+      translationGe: "to tell of (sth.)",
+      exampleSentence: "Der Bischoff erzählt von der Reise nach Rom."
     },
     {
       pVerb: "fragen",
       prae: "nach",
       kasus: "D",
-      translationGe: "to ask for (sth.)"
+      translationGe: "to ask for (sth.)",
+      exampleSentence: "Die Journalistin fragt nach den Konsequenzen der Gesetzesänderung."
     },
     {
       pVerb: "sich freuen",
       prae: "auf",
       kasus: "A",
-      translationGe: "to look forward to (sth.)"
+      translationGe: "to look forward to (sth.)",
+      exampleSentence: "Kinder freuen sich auf Weihnachten."
     },
     {
       pVerb: "sich freuen",
       prae: "über",
       kasus: "A",
-      translationGe: "to be happy about (sth.)"
+      translationGe: "to be happy about (sth.)",
+      exampleSentence: "Jeder freut sich über eine Gehaltserhöhung."
     },
     {
       pVerb: "gehen",
       prae: "um",
       kasus: "A",
-      translationGe: "To be about (sth.)"
+      translationGe: "To be about (sth.)",
+      exampleSentence: "Immer geht es um Geld."
     },
     {
       pVerb: "gehören",
       prae: "zu",
       kasus: "D",
-      translationGe: "to belong to (sth.)"
+      translationGe: "to belong to (sth.)",
+      exampleSentence: "Das Elsass gehört zu Frankreich."
     },
     {
       pVerb: "sich gewöhnen",
       prae: "an",
       kasus: "A",
-      translationGe: "to adjust to (sth.)"
+      translationGe: "to adjust to (sth.)",
+      exampleSentence: "Ich kann mich nicht an den Euro gewöhnen."
     },
     {
       pVerb: "glauben",
       prae: "an",
       kasus: "A",
-      translationGe: "to believe in (sth.)"
+      translationGe: "to believe in (sth.)",
+      exampleSentence: "Teenager glauben an die große Liebe."
     },
     {
       pVerb: "gratulieren",
       prae: "zu",
       kasus: "D",
-      translationGe: "to congratulate on (sth.)"
+      translationGe: "to congratulate on (sth.)",
+      exampleSentence: "Wir gratulieren dir zum 18. Geburtstag."
     },
     {
       pVerb: "halten",
       prae: "für",
       kasus: "A",
-      translationGe: "to perceive as (sth.)"
+      translationGe: "to perceive as (sth.)",
+      exampleSentence: "Ich halte das für keine gute Idee."
     },
     {
       pVerb: "halten",
       prae: "von",
       kasus: "D",
-      translationGe: "to think (sth.) of (so.)"
+      translationGe: "to think (sth.) of (sth./so.)",
+      exampleSentence: "Kinder halten nicht viel von Ordnung."
     },
     {
       pVerb: "sich handeln",
       prae: "um",
       kasus: "A",
-      translationGe: "to be about (sth.)"
+      translationGe: "to be about (sth.)",
+      exampleSentence: "Bei der Kopie handelt es sich nicht um Originalsoftware."
     },
     {
       pVerb: "handeln",
       prae: "von",
       kasus: "D",
-      translationGe: "to be about (sth.)"
+      translationGe: "to be about (sth.)",
+      exampleSentence: "Märchen handeln von Gut und Böse."
     },
     {
       pVerb: "helfen",
       prae: "bei",
       kasus: "D",
-      translationGe: "to assist with (sth.)"
+      translationGe: "to assist with (sth.)",
+      exampleSentence: "Kann ich dir beim Tischdecken helfen?"
     },
     {
       pVerb: "hindern",
       prae: "an",
       kasus: "D",
-      translationGe: "to hinder (sth.)"
+      translationGe: "to hinder (sth.)",
+      exampleSentence: "Ein langsamer Fahrer hindert Greta am Überholen."
     },
     {
       pVerb: "hoffen",
       prae: "auf",
       kasus: "A",
-      translationGe: "to hope for (sth.)"
+      translationGe: "to hope for (sth.)",
+      exampleSentence: "Im März hoffen alle auf warme Frühlingstage."
     },
     {
       pVerb: "sich informieren",
       prae: "über",
       kasus: "A",
-      translationGe: "to read up on (sth.)"
+      translationGe: "to read up on (sth.)",
+      exampleSentence: "Auf der Messe kann man sich über die neue Technologie informieren."
     },
     {
       pVerb: "sich interessieren",
       prae: "für",
       kasus: "A",
-      translationGe: "to be interested in (sth.)"
+      translationGe: "to be interested in (sth.)",
+      exampleSentence: "Monika interessiert sich für ein Smartphone."
     },
     {
       pVerb: "klagen",
       prae: "über",
       kasus: "A",
-      translationGe: "to complain about (sth.)"
+      translationGe: "to complain about (sth.)",
+      exampleSentence: "Frauen klagen häufig über Kopfschmerzen."
     },
     {
       pVerb: "kämpfen",
       prae: "für",
       kasus: "A",
-      translationGe: "to fight for (sth.)"
+      translationGe: "to fight for (sth.)",
+      exampleSentence: "Die Gewerkschaft kämpft für höhere Löhne."
     },
     {
       pVerb: "kommen",
       prae: "zu",
       kasus: "D",
-      translationGe: "to arrive at (sth.)"
+      translationGe: "to come to (sth.)",
+      exampleSentence: "In der Besprechung kam es zu einem Streit."
     },
     {
       pVerb: "sich konzentrieren",
       prae: "auf",
       kasus: "A",
-      translationGe: "to focus on (sth.)"
+      translationGe: "to focus on (sth.)",
+      exampleSentence: "Karl konzentriert sich auf seine Hausaufgaben."
     },
     {
       pVerb: "sich kümmern",
       prae: "um",
       kasus: "A",
-      translationGe: "to take care of (sth.)"
+      translationGe: "to take care of (sth.)",
+      exampleSentence: "Im Pflegeheim kümmert man sich um alte Leute, die krank sind."
     },
     {
       pVerb: "lachen",
       prae: "über",
       kasus: "A",
-      translationGe: "to laugh about (sth.)"
+      translationGe: "to laugh about (sth.)",
+      exampleSentence: "Über einen guten Witz muss man laut lachen."
     },
     {
       pVerb: "leiden",
       prae: "an",
       kasus: "D",
-      translationGe: "to suffer from (sth.)"
+      translationGe: "to suffer from (sth.)",
+      exampleSentence: "Jeder fünfte Manager leidet an Burn-out."
     },
     {
       pVerb: "leiden",
       prae: "unter",
       kasus: "A",
-      translationGe: "to suffer from (sth.)"
+      translationGe: "to suffer from (sth.)",
+      exampleSentence: "Kaffetrinker leiden unter Schlafproblemen."
     },
     {
       pVerb: "nachdenken",
       prae: "über",
       kasus: "A",
-      translationGe: "to reflect on (sth.)"
+      translationGe: "to reflect on (sth.)",
+      exampleSentence: "Beamte müssen nicht über ihre Rente nachdenken."
     },
     {
       pVerb: "protestieren",
       prae: "gegen",
       kasus: "A",
-      translationGe: "to protest against (sth.)"
+      translationGe: "to protest against (sth.)",
+      exampleSentence: "Viele Menschen protestieren gegen Atomkraft."
     },
     {
       pVerb: "rechnen",
       prae: "mit",
       kasus: "D",
-      translationGe: "to count on (sth.)"
+      translationGe: "to expect (sth.)",
+      exampleSentence: "Im Januar muss man mit Schnee rechnen."
     },
     {
       pVerb: "reden",
       prae: "über",
       kasus: "A",
-      translationGe: "to talk about (sth.)"
+      translationGe: "to talk about (sth.)",
+      exampleSentence: "Deine Mutter redet gern über Krankheiten."
     },
     {
       pVerb: "reden",
       prae: "von",
       kasus: "D",
-      translationGe: "to talk about (sth.)"
+      translationGe: "to talk about (sth.)",
+      exampleSentence: "Großvater redet von den guten alten Zeiten."
     },
     {
       pVerb: "riechen",
       prae: "nach",
       kasus: "D",
-      translationGe: "to smell of (sth.)"
+      translationGe: "to smell of (sth.)",
+      exampleSentence: "Hier riecht es nach Kuchen."
     },
     {
       pVerb: "sagen",
       prae: "über",
       kasus: "A",
-      translationGe: "to say (sth.)"
+      translationGe: "to say (sth.)",
+      exampleSentence: "Brigitte sagt über Dietmar, dass er oft lügt."
     },
     {
       pVerb: "sagen",
       prae: "zu",
       kasus: "D",
-      translationGe: "to agree to sth."
+      translationGe: "to say (sth.) to (sth.)",
+      exampleSentence: "Was sagst du zu meinem neuen Haarschnitt?"
     },
     {
       pVerb: "schicken",
       prae: "an",
       kasus: "A",
-      translationGe: "to send (sth.) to (so.)"
+      translationGe: "to send (sth.) to (so.)",
+      exampleSentence: "Die E-Mail schicke ich dir morgen."
     },
     {
       pVerb: "schicken",
       prae: "zu",
       kasus: "D",
-      translationGe: "to send (sth.) to (so.)"
+      translationGe: "to send (so./sth.) to (so.)",
+      exampleSentence: "Der Allgemeinmediziner schickt den Patienten zu einem Spezialisten."
     },
     {
       pVerb: "schimpfen",
       prae: "über",
       kasus: "A",
-      translationGe: "to rant about (sth.)"
+      translationGe: "to rant about (sth.)",
+      exampleSentence: "Alle schimpfen über den Regen."
     },
     {
       pVerb: "schmecken",
       prae: "nach",
       kasus: "D",
-      translationGe: "to taste of (sth.)"
+      translationGe: "to taste of (sth.)",
+      exampleSentence: "Muscheln schmecken nach Meerwasser."
     },
     {
       pVerb: "schreiben",
       prae: "an",
       kasus: "A",
-      translationGe: "to write (sth.)"
+      translationGe: "to write to (so.)",
+      exampleSentence: "Bitte schreibe noch heute an deine Mutter."
     },
     {
       pVerb: "sich schützen",
       prae: "vor",
       kasus: "D",
-      translationGe: "to protext from (sth.)"
+      translationGe: "to protext from (sth.)",
+      exampleSentence: "Den Computer des Ministers muss man vor Hackern schützen."
     },
     {
       pVerb: "sein",
       prae: "für",
       kasus: "A",
-      translationGe: "to be in favor of (sth.)"
+      translationGe: "to be in favor of (sth.)",
+      exampleSentence: "Ich bin für die Abschaffung der Kinderarbeit."
     },
     {
       pVerb: "sein",
       prae: "gegen",
       kasus: "A",
-      translationGe: "to disapprove of (sth.)"
+      translationGe: "to disapprove of (sth.)",
+      exampleSentence: "Viele sind gegen Steuererhöhungen."
     },
     {
       pVerb: "sorgen",
       prae: "für",
       kasus: "A",
-      translationGe: "to see for (sth.)"
+      translationGe: "to see for (sth.)",
+      exampleSentence: "Kinder müssen im Alter für ihre Eltern sorgen."
     },
     {
       pVerb: "sprechen",
       prae: "mit",
       kasus: "D",
-      translationGe: "to talk to (so.)"
+      translationGe: "to talk to (so.)",
+      exampleSentence: "Ich spreche noch einmal mit deinem Vater."
     },
     {
       pVerb: "sprechen",
       prae: "über",
       kasus: "A",
-      translationGe: "to talk about (sth.)"
+      translationGe: "to talk about (sth.)",
+      exampleSentence: "Lass uns über deine Zukunft sprechen."
     },
     {
       pVerb: "sterben",
       prae: "an",
       kasus: "D",
-      translationGe: "to die of (sth.)"
+      translationGe: "to die of (sth.)",
+      exampleSentence: "Zwei Deutsche sind an der Grippe gestorben."
     },
     {
       pVerb: "streiten",
       prae: "mit",
       kasus: "D",
-      translationGe: "to argue with (so.)"
+      translationGe: "to argue with (so.)",
+      exampleSentence: "Ich möchte nicht mit dir streiten."
     },
     {
       pVerb: "streiten",
       prae: "über",
       kasus: "A",
-      translationGe: "to argue about (sth.)"
+      translationGe: "to argue about (sth.)",
+      exampleSentence: "Die USA und Deutschland streiten sich über eine neue Strategie."
     },
     {
       pVerb: "teilnehmen",
       prae: "an",
       kasus: "D",
-      translationGe: "to participate in (sth.)"
+      translationGe: "to participate in (sth.)",
+      exampleSentence: "Nordkorea nimmt an der Fußball-WM teil."
     },
     {
       pVerb: "telefonieren",
       prae: "mit",
       kasus: "D",
-      translationGe: "to talk to (so.) on the phone"
+      translationGe: "to talk to (so.) on the phone",
+      exampleSentence: "Hast du schon mit dem Arzt telefoniert?"
     },
     {
       pVerb: "sich treffen",
       prae: "mit",
       kasus: "D",
-      translationGe: "to meet with (so.)"
+      translationGe: "to meet with (so.)",
+      exampleSentence: "Die Kanzlerin trifft sich täglich mit ihrem Pressesprecher."
     },
     {
       pVerb: "sich treffen",
       prae: "zu",
       kasus: "D",
-      translationGe: "to meet for (sth.)"
+      translationGe: "to meet for (sth.)",
+      exampleSentence: "Sie treffen sich nur zu einem kurzen Gespräch."
     },
     {
       pVerb: "überreden",
       prae: "zu",
       kasus: "D",
-      translationGe: "to persuade (so.) to do (sth.)"
+      translationGe: "to persuade (so.) to do (sth.)",
+      exampleSentence: "Kann ich dich zu einem Glas Wein überreden?"
     },
     {
       pVerb: "sich unterhalten",
       prae: "mit",
       kasus: "D",
-      translationGe: "to talk to (so.)"
+      translationGe: "to talk to (so.)",
+      exampleSentence: "Der Sänger unterhält sich mit dem Bassisten."
     },
     {
       pVerb: "sich unterhalten",
       prae: "über",
       kasus: "A",
-      translationGe: "to talk about (sth.)"
+      translationGe: "to talk about (sth.)",
+      exampleSentence: "Die Modedesigner unterhalten sich über die neuesten Trends."
     },
     {
       pVerb: "sich verabreden",
       prae: "mit",
       kasus: "D",
-      translationGe: "to arrange to meet (so.)"
+      translationGe: "to arrange to meet (so.)",
+      exampleSentence: "Heute verabrede ich mich mit einer Freundin."
     },
     {
       pVerb: "sich verabschieden",
       prae: "von",
       kasus: "D",
-      translationGe: "to say goodbye to (sth.)"
+      translationGe: "to say goodbye to (sth.)",
+      exampleSentence: "Nun wollen wir uns von euch verabschieden."
     },
     {
       pVerb: "vergleichen",
       prae: "mit",
       kasus: "D",
-      translationGe: "to compare to (sth.)"
+      translationGe: "to compare to (sth.)",
+      exampleSentence: "Vergleichen Sie München mit Berlin."
     },
     {
       pVerb: "sich verlassen",
       prae: "auf",
       kasus: "A",
-      translationGe: "to rely on sth."
+      translationGe: "to rely on sth.",
+      exampleSentence: "Auf mich kann man sich verlassen."
     },
     {
       pVerb: "sich verlieben",
       prae: "in",
       kasus: "A",
-      translationGe: "to fall in love with (so.)"
+      translationGe: "to fall in love with (so.)",
+      exampleSentence: "Britta hat sich in das alte Bauernhaus verliebt."
     },
     {
       pVerb: "sich verstehen",
       prae: "mit",
       kasus: "D",
-      translationGe: "to get along with (so.)"
+      translationGe: "to get along with (so.)",
+      exampleSentence: "Daniel versteht sich gut mit seinem Chef."
     },
     {
       pVerb: "verstehen",
       prae: "von",
       kasus: "D",
-      translationGe: "to know a lot about (sth.)"
+      translationGe: "to know a lot about (sth.)",
+      exampleSentence: "Verstehst du was von Elektrik?"
     },
     {
       pVerb: "sich vorbereiten",
       prae: "auf",
       kasus: "A",
-      translationGe: "to prepare for (sth.)"
+      translationGe: "to prepare for (sth.)",
+      exampleSentence: "Karl bereitet sich auf eine Präsentation vor."
     },
     {
       pVerb: "warnen",
       prae: "vor",
       kasus: "D",
-      translationGe: "to warn of (sth.)"
+      translationGe: "to warn of (sth.)",
+      exampleSentence: "Man hatte ihn vor den hohen Kosten für das alte Auto gewarnt."
     },
     {
       pVerb: "warten",
       prae: "auf",
       kasus: "A",
-      translationGe: "to wait for (sth.)"
+      translationGe: "to wait for (sth.)",
+      exampleSentence: "In Namibia wartet man lange auf einen Bus."
     },
     {
       pVerb: "sich wenden",
       prae: "an",
       kasus: "A",
-      translationGe: "to approach (so.)"
+      translationGe: "to approach (so.)",
+      exampleSentence: "Bitte wenden Sie sich an die Buchhaltung."
     },
     {
       pVerb: "werden",
       prae: "zu",
       kasus: "D",
-      translationGe: "to turn into (sth.)"
+      translationGe: "to turn into (sth.)",
+      exampleSentence: "Unter null Grad wird Eis zu Wasser."
     },
     {
       pVerb: "wissen",
       prae: "von",
       kasus: "D",
-      translationGe: "to know about (sth.)"
+      translationGe: "to know about (sth.)",
+      exampleSentence: "Ich weiß nichts von neuen Computern für unser Team."
     },
     {
       pVerb: "sich wundern",
       prae: "über",
       kasus: "A",
-      translationGe: "to wonder at (sth.)"
+      translationGe: "to wonder at (sth.)",
+      exampleSentence: "Viele Deutsche wundern sich über die plötzlich zu hohen Stromkosten."
     },
     {
       pVerb: "zuschauen",
       prae: "bei",
       kasus: "D",
-      translationGe: "to watch (sth.)"
+      translationGe: "to watch (sth.)",
+      exampleSentence: "Kann ich dir bei der Reparatur zuschauen?"
     },
     {
       pVerb: "zusehen",
       prae: "bei",
       kasus: "D",
-      translationGe: "to watch (sth.)"
+      translationGe: "to watch (sth.)",
+      exampleSentence: "Willst du mir beim Kochen zusehen?"
     },
     {
       pVerb: "zweifeln",
       prae: "an",
       kasus: "D",
-      translationGe: "to doubt (sth.)"
+      translationGe: "to doubt (sth.)",
+      exampleSentence: "John zweifelt daran, dass sein Sohn die Wahrheit gesagt hat."
     }
   ]
 };

--- a/src/containers/data/phrasalVerbsGe.ts
+++ b/src/containers/data/phrasalVerbsGe.ts
@@ -4,667 +4,667 @@ export default {
       pVerb: "abhängen",
       prae: "von",
       kasus: "D",
-	  translationGe: "to depend on (sth.)"
+      translationGe: "to depend on (sth.)"
     },
     {
       pVerb: "achten",
       prae: "auf",
       kasus: "A",
-	  translationGe: "to mind (sth.)"
+      translationGe: "to mind (sth.)"
     },
     {
       pVerb: "anfangen",
       prae: "mit",
       kasus: "D",
-	  translationGe: "to start with (sth.)"
+      translationGe: "to start with (sth.)"
     },
     {
       pVerb: "ankommen",
       prae: "auf",
       kasus: "A",
-	  translationGe: "to depend on (sth.)"
+      translationGe: "to depend on (sth.)"
     },
     {
       pVerb: "antworten",
       prae: "auf",
       kasus: "A",
-	  translationGe: "to respond to (sth.)"
+      translationGe: "to respond to (sth.)"
     },
     {
       pVerb: "sich ärgern",
       prae: "über",
       kasus: "A",
-	  translationGe: "to get angry about (sth.)"
+      translationGe: "to get angry about (sth.)"
     },
     {
       pVerb: "aufhören",
       prae: "mit",
       kasus: "D",
-	  translationGe: "to stop with (sth.)"
+      translationGe: "to stop with (sth.)"
     },
     {
       pVerb: "aufpassen",
       prae: "auf",
       kasus: "A",
-	  translationGe: "to pay attention to (sth.)"
+      translationGe: "to pay attention to (sth.)"
     },
     {
       pVerb: "sich aufregen",
       prae: "über",
       kasus: "A",
-	  translationGe: "to get upset about (sth.)"
+      translationGe: "to get upset about (sth.)"
     },
     {
       pVerb: "ausgeben",
       prae: "für",
       kasus: "A",
-	  translationGe: "to pay for (sth.)"
+      translationGe: "to pay for (sth.)"
     },
     {
       pVerb: "sich bedanken",
       prae: "bei",
       kasus: "D",
-	  translationGe: "to thank (so.)"
+      translationGe: "to thank (so.)"
     },
     {
       pVerb: "sich bedanken",
       prae: "für",
       kasus: "A",
-	  translationGe: "to thank for (sth.)"
+      translationGe: "to thank for (sth.)"
     },
     {
       pVerb: "beginnen",
       prae: "mit",
       kasus: "D",
-	  translationGe: "to start with (sth.)"
+      translationGe: "to start with (sth.)"
     },
     {
       pVerb: "sich bemühen",
       prae: "um",
       kasus: "A",
-	  translationGe: "to go after (sth.)"
+      translationGe: "to go after (sth.)"
     },
     {
       pVerb: "berichten",
       prae: "über",
       kasus: "A",
-	  translationGe: "to report on (sth.)"
+      translationGe: "to report on (sth.)"
     },
     {
       pVerb: "sich beschäftigen",
       prae: "mit",
       kasus: "D",
-	  translationGe: "to occupy oneself with (sth.)"
+      translationGe: "to occupy oneself with (sth.)"
     },
     {
       pVerb: "sich beschweren",
       prae: "bei",
       kasus: "D",
-	  translationGe: "to complain to (sb.)"
+      translationGe: "to complain to (sb.)"
     },
     {
       pVerb: "bestehen",
       prae: "aus",
       kasus: "D",
-	  translationGe: "to consist of (sth.)"
+      translationGe: "to consist of (sth.)"
     },
     {
       pVerb: "bestehen",
       prae: "auf",
       kasus: "A",
-	  translationGe: "to insist on (sth.)"
+      translationGe: "to insist on (sth.)"
     },
     {
       pVerb: "sich beteiligen",
       prae: "an",
       kasus: "D",
-	  translationGe: "to take part in (sth.)"
+      translationGe: "to take part in (sth.)"
     },
     {
       pVerb: "sich bewerben",
       prae: "bei",
       kasus: "D",
-	  translationGe: "to apply to (so.)"
+      translationGe: "to apply to (so.)"
     },
     {
       pVerb: "sich bewerben",
       prae: "um",
       kasus: "A",
-	  translationGe: "to apply for (sth.)"
+      translationGe: "to apply for (sth.)"
     },
     {
       pVerb: "sich beziehen",
       prae: "auf",
       kasus: "A",
-	  translationGe: "to refer to (sth.)"
+      translationGe: "to refer to (sth.)"
     },
     {
       pVerb: "bitten",
       prae: "um",
       kasus: "A",
-	  translationGe: "to ask for (sth.)"
+      translationGe: "to ask for (sth.)"
     },
     {
       pVerb: "danken",
       prae: "für",
       kasus: "A",
-	  translationGe: "to thank for (sth.)"
+      translationGe: "to thank for (sth.)"
     },
     {
       pVerb: "denken",
       prae: "an",
       kasus: "A",
-	  translationGe: "to think of (sth.)"
+      translationGe: "to think of (sth.)"
     },
     {
       pVerb: "diskutieren",
       prae: "über",
       kasus: "A",
-	  translationGe: "to discuss (sth.)"
+      translationGe: "to discuss (sth.)"
     },
     {
       pVerb: "einladen",
       prae: "zu",
       kasus: "D",
-	  translationGe: "to invite (sb.) to (sth.)"
+      translationGe: "to invite (sb.) to (sth.)"
     },
     {
       pVerb: "sich entscheiden",
       prae: "für",
       kasus: "A",
-	  translationGe: "to decide on (sth.)"
+      translationGe: "to decide on (sth.)"
     },
     {
       pVerb: "sich entschließen",
       prae: "zu",
       kasus: "D",
-	  translationGe: "to decide to (sth.)"
+      translationGe: "to decide to (sth.)"
     },
     {
       pVerb: "sich entschuldigen",
       prae: "bei",
       kasus: "D",
-	  translationGe: "to apologize by (so.)"
+      translationGe: "to apologize by (so.)"
     },
     {
       pVerb: "sich entschuldigen",
       prae: "für",
       kasus: "A",
-	  translationGe: "to apologize for (sth.)"
+      translationGe: "to apologize for (sth.)"
     },
     {
       pVerb: "erfahren",
       prae: "von",
       kasus: "D",
-	  translationGe: "to find out about (sth.)"
+      translationGe: "to find out about (sth.)"
     },
     {
       pVerb: "sich erholen",
       prae: "von",
       kasus: "D",
-	  translationGe: "to recover from (sth.)"
+      translationGe: "to recover from (sth.)"
     },
     {
       pVerb: "sich erinnern",
       prae: "an",
       kasus: "A",
-	  translationGe: "to remember (sth.)"
+      translationGe: "to remember (sth.)"
     },
     {
       pVerb: "erkennen",
       prae: "an",
       kasus: "D",
-	  translationGe: "to recognize from (sth.)"
+      translationGe: "to recognize from (sth.)"
     },
     {
       pVerb: "sich erkundigen",
       prae: "nach",
       kasus: "D",
-	  translationGe: "to inquire about (sth.)"
+      translationGe: "to inquire about (sth.)"
     },
     {
       pVerb: "erschrecken",
       prae: "über",
       kasus: "A",
-	  translationGe: "to get spooked by (sth.)"
+      translationGe: "to get spooked by (sth.)"
     },
     {
       pVerb: "erzählen",
       prae: "über",
       kasus: "A",
-	  translationGe: "to tell (sth.)"
+      translationGe: "to tell (sth.)"
     },
     {
       pVerb: "erzählen",
       prae: "von",
       kasus: "D",
-	  translationGe: "to tell of (sth.)"
+      translationGe: "to tell of (sth.)"
     },
     {
       pVerb: "fragen",
       prae: "nach",
       kasus: "D",
-	  translationGe: "to ask for (sth.)"
+      translationGe: "to ask for (sth.)"
     },
     {
       pVerb: "sich freuen",
       prae: "auf",
       kasus: "A",
-	  translationGe: "to look forward to (sth.)"
+      translationGe: "to look forward to (sth.)"
     },
     {
       pVerb: "sich freuen",
       prae: "über",
       kasus: "A",
-	  translationGe: "to be happy about (sth.)"
+      translationGe: "to be happy about (sth.)"
     },
     {
       pVerb: "gehen",
       prae: "um",
       kasus: "A",
-	  translationGe: "To be about (sth.)"
+      translationGe: "To be about (sth.)"
     },
     {
       pVerb: "gehören",
       prae: "zu",
       kasus: "D",
-	  translationGe: "to belong to (sth.)"
+      translationGe: "to belong to (sth.)"
     },
     {
       pVerb: "sich gewöhnen",
       prae: "an",
       kasus: "A",
-	  translationGe: "to adjust to (sth.)"
+      translationGe: "to adjust to (sth.)"
     },
     {
       pVerb: "glauben",
       prae: "an",
       kasus: "A",
-	  translationGe: "to believe in (sth.)"
+      translationGe: "to believe in (sth.)"
     },
     {
       pVerb: "gratulieren",
       prae: "zu",
       kasus: "D",
-	  translationGe: "to congratulate on (sth.)"
+      translationGe: "to congratulate on (sth.)"
     },
     {
       pVerb: "halten",
       prae: "für",
       kasus: "A",
-	  translationGe: "to perceive as (sth.)"
+      translationGe: "to perceive as (sth.)"
     },
     {
       pVerb: "halten",
       prae: "von",
       kasus: "D",
-	  translationGe: "to think (sth.) of (so.)"
+      translationGe: "to think (sth.) of (so.)"
     },
     {
       pVerb: "sich handeln",
       prae: "um",
       kasus: "A",
-	  translationGe: "to be about (sth.)"
+      translationGe: "to be about (sth.)"
     },
     {
       pVerb: "handeln",
       prae: "von",
       kasus: "D",
-	  translationGe: "to be about (sth.)"
+      translationGe: "to be about (sth.)"
     },
     {
       pVerb: "helfen",
       prae: "bei",
       kasus: "D",
-	  translationGe: "to assist with (sth.)"
+      translationGe: "to assist with (sth.)"
     },
     {
       pVerb: "hindern",
       prae: "an",
       kasus: "D",
-	  translationGe: "to hinder (sth.)"
+      translationGe: "to hinder (sth.)"
     },
     {
       pVerb: "hoffen",
       prae: "auf",
       kasus: "A",
-	  translationGe: "to hope for (sth.)"
+      translationGe: "to hope for (sth.)"
     },
     {
       pVerb: "sich informieren",
       prae: "über",
       kasus: "A",
-	  translationGe: "to read up on (sth.)"
+      translationGe: "to read up on (sth.)"
     },
     {
       pVerb: "sich interessieren",
       prae: "für",
       kasus: "A",
-	  translationGe: "to be interested in (sth.)"
+      translationGe: "to be interested in (sth.)"
     },
     {
       pVerb: "klagen",
       prae: "über",
       kasus: "A",
-	  translationGe: "to complain about (sth.)"
+      translationGe: "to complain about (sth.)"
     },
     {
       pVerb: "kämpfen",
       prae: "für",
       kasus: "A",
-	  translationGe: "to fight for (sth.)"
+      translationGe: "to fight for (sth.)"
     },
     {
       pVerb: "kommen",
       prae: "zu",
       kasus: "D",
-	  translationGe: "to arrive at (sth.)"
+      translationGe: "to arrive at (sth.)"
     },
     {
       pVerb: "sich konzentrieren",
       prae: "auf",
       kasus: "A",
-	  translationGe: "to focus on (sth.)"
+      translationGe: "to focus on (sth.)"
     },
     {
       pVerb: "sich kümmern",
       prae: "um",
       kasus: "A",
-	  translationGe: "to take care of (sth.)"
+      translationGe: "to take care of (sth.)"
     },
     {
       pVerb: "lachen",
       prae: "über",
       kasus: "A",
-	  translationGe: "to laugh about (sth.)"
+      translationGe: "to laugh about (sth.)"
     },
     {
       pVerb: "leiden",
       prae: "an",
       kasus: "D",
-	  translationGe: "to suffer from (sth.)"
+      translationGe: "to suffer from (sth.)"
     },
     {
       pVerb: "leiden",
       prae: "unter",
       kasus: "A",
-	  translationGe: "to suffer from (sth.)"
+      translationGe: "to suffer from (sth.)"
     },
     {
       pVerb: "nachdenken",
       prae: "über",
       kasus: "A",
-	  translationGe: "to reflect on (sth.)"
+      translationGe: "to reflect on (sth.)"
     },
     {
       pVerb: "protestieren",
       prae: "gegen",
       kasus: "A",
-	  translationGe: "to protest against (sth.)"
+      translationGe: "to protest against (sth.)"
     },
     {
       pVerb: "rechnen",
       prae: "mit",
       kasus: "D",
-	  translationGe: "to count on (sth.)"
+      translationGe: "to count on (sth.)"
     },
     {
       pVerb: "reden",
       prae: "über",
       kasus: "A",
-	  translationGe: "to talk about (sth.)"
+      translationGe: "to talk about (sth.)"
     },
     {
       pVerb: "reden",
       prae: "von",
       kasus: "D",
-	  translationGe: "to talk about (sth.)"
+      translationGe: "to talk about (sth.)"
     },
     {
       pVerb: "riechen",
       prae: "nach",
       kasus: "D",
-	  translationGe: "to smell of (sth.)"
+      translationGe: "to smell of (sth.)"
     },
     {
       pVerb: "sagen",
       prae: "über",
       kasus: "A",
-	  translationGe: "to say (sth.)"
+      translationGe: "to say (sth.)"
     },
     {
       pVerb: "sagen",
       prae: "zu",
       kasus: "D",
-	  translationGe: "to agree to sth."
+      translationGe: "to agree to sth."
     },
     {
       pVerb: "schicken",
       prae: "an",
       kasus: "A",
-	  translationGe: "to send (sth.) to (so.)"
+      translationGe: "to send (sth.) to (so.)"
     },
     {
       pVerb: "schicken",
       prae: "zu",
       kasus: "D",
-	  translationGe: "to send (sth.) to (so.)"
+      translationGe: "to send (sth.) to (so.)"
     },
     {
       pVerb: "schimpfen",
       prae: "über",
       kasus: "A",
-	  translationGe: "to rant about (sth.)"
+      translationGe: "to rant about (sth.)"
     },
     {
       pVerb: "schmecken",
       prae: "nach",
       kasus: "D",
-	  translationGe: "to taste of (sth.)"
+      translationGe: "to taste of (sth.)"
     },
     {
       pVerb: "schreiben",
       prae: "an",
       kasus: "A",
-	  translationGe: "to write (sth.)"
+      translationGe: "to write (sth.)"
     },
     {
       pVerb: "sich schützen",
       prae: "vor",
       kasus: "D",
-	  translationGe: "to protext from (sth.)"
+      translationGe: "to protext from (sth.)"
     },
     {
       pVerb: "sein",
       prae: "für",
       kasus: "A",
-	  translationGe: "to be in favor of (sth.)"
+      translationGe: "to be in favor of (sth.)"
     },
     {
       pVerb: "sein",
       prae: "gegen",
       kasus: "A",
-	  translationGe: "to disapprove of (sth.)"
+      translationGe: "to disapprove of (sth.)"
     },
     {
       pVerb: "sorgen",
       prae: "für",
       kasus: "A",
-	  translationGe: "to see for (sth.)"
+      translationGe: "to see for (sth.)"
     },
     {
       pVerb: "sprechen",
       prae: "mit",
       kasus: "D",
-	  translationGe: "to talk to (so.)"
+      translationGe: "to talk to (so.)"
     },
     {
       pVerb: "sprechen",
       prae: "über",
       kasus: "A",
-	  translationGe: "to talk about (sth.)"
+      translationGe: "to talk about (sth.)"
     },
     {
       pVerb: "sterben",
       prae: "an",
       kasus: "D",
-	  translationGe: "to die of (sth.)"
+      translationGe: "to die of (sth.)"
     },
     {
       pVerb: "streiten",
       prae: "mit",
       kasus: "D",
-	  translationGe: "to argue with (so.)"
+      translationGe: "to argue with (so.)"
     },
     {
       pVerb: "streiten",
       prae: "über",
       kasus: "A",
-	  translationGe: "to argue about (sth.)"
+      translationGe: "to argue about (sth.)"
     },
     {
       pVerb: "teilnehmen",
       prae: "an",
       kasus: "D",
-	  translationGe: "to participate in (sth.)"
+      translationGe: "to participate in (sth.)"
     },
     {
       pVerb: "telefonieren",
       prae: "mit",
       kasus: "D",
-	  translationGe: "to talk to (so.) on the phone"
+      translationGe: "to talk to (so.) on the phone"
     },
     {
       pVerb: "sich treffen",
       prae: "mit",
       kasus: "D",
-	  translationGe: "to meet with (so.)"
+      translationGe: "to meet with (so.)"
     },
     {
       pVerb: "sich treffen",
       prae: "zu",
       kasus: "D",
-	  translationGe: "to meet for (sth.)"
+      translationGe: "to meet for (sth.)"
     },
     {
       pVerb: "überreden",
       prae: "zu",
       kasus: "D",
-	  translationGe: "to persuade (so.) to do (sth.)"
+      translationGe: "to persuade (so.) to do (sth.)"
     },
     {
       pVerb: "sich unterhalten",
       prae: "mit",
       kasus: "D",
-	  translationGe: "to talk to (so.)"
+      translationGe: "to talk to (so.)"
     },
     {
       pVerb: "sich unterhalten",
       prae: "über",
       kasus: "A",
-	  translationGe: "to talk about (sth.)"
+      translationGe: "to talk about (sth.)"
     },
     {
       pVerb: "sich verabreden",
       prae: "mit",
       kasus: "D",
-	  translationGe: "to arrange to meet (so.)"
+      translationGe: "to arrange to meet (so.)"
     },
     {
       pVerb: "sich verabschieden",
       prae: "von",
       kasus: "D",
-	  translationGe: "to say goodbye to (sth.)"
+      translationGe: "to say goodbye to (sth.)"
     },
     {
       pVerb: "vergleichen",
       prae: "mit",
       kasus: "D",
-	  translationGe: "to compare to (sth.)"
+      translationGe: "to compare to (sth.)"
     },
     {
       pVerb: "sich verlassen",
       prae: "auf",
       kasus: "A",
-	  translationGe: "to rely on sth."
+      translationGe: "to rely on sth."
     },
     {
       pVerb: "sich verlieben",
       prae: "in",
       kasus: "A",
-	  translationGe: "to fall in love with (so.)"
+      translationGe: "to fall in love with (so.)"
     },
     {
       pVerb: "sich verstehen",
       prae: "mit",
       kasus: "D",
-	  translationGe: "to get along with (so.)"
+      translationGe: "to get along with (so.)"
     },
     {
       pVerb: "verstehen",
       prae: "von",
       kasus: "D",
-	  translationGe: "to know a lot about (sth.)"
+      translationGe: "to know a lot about (sth.)"
     },
     {
       pVerb: "sich vorbereiten",
       prae: "auf",
       kasus: "A",
-	  translationGe: "to prepare for (sth.)"
+      translationGe: "to prepare for (sth.)"
     },
     {
       pVerb: "warnen",
       prae: "vor",
       kasus: "D",
-	  translationGe: "to warn of (sth.)"
+      translationGe: "to warn of (sth.)"
     },
     {
       pVerb: "warten",
       prae: "auf",
       kasus: "A",
-	  translationGe: "to wait for (sth.)"
+      translationGe: "to wait for (sth.)"
     },
     {
       pVerb: "sich wenden",
       prae: "an",
       kasus: "A",
-	  translationGe: "to approach (so.)"
+      translationGe: "to approach (so.)"
     },
     {
       pVerb: "werden",
       prae: "zu",
       kasus: "D",
-	  translationGe: "to turn into (sth.)"
+      translationGe: "to turn into (sth.)"
     },
     {
       pVerb: "wissen",
       prae: "von",
       kasus: "D",
-	  translationGe: "to know about (sth.)"
+      translationGe: "to know about (sth.)"
     },
     {
       pVerb: "sich wundern",
       prae: "über",
       kasus: "A",
-	  translationGe: "to wonder at (sth.)"
+      translationGe: "to wonder at (sth.)"
     },
     {
       pVerb: "zuschauen",
       prae: "bei",
       kasus: "D",
-	  translationGe: "to watch (sth.)"
+      translationGe: "to watch (sth.)"
     },
     {
       pVerb: "zusehen",
       prae: "bei",
       kasus: "D",
-	  translationGe: "to watch (sth.)"
+      translationGe: "to watch (sth.)"
     },
     {
       pVerb: "zweifeln",
       prae: "an",
       kasus: "D",
-	  translationGe: "to doubt (sth.)"
+      translationGe: "to doubt (sth.)"
     }
   ]
 };


### PR DESCRIPTION
Example sentences were added according to [this list](https://de.pons.com/daten/pdf/Praxis-Grammatik/01_Verben_mit_Praepositionen.pdf).

Additionally, the english translation of some german verbs were changed to better fit the examples given in the list.

This PR should close #25 